### PR TITLE
Clearer date format instructions.

### DIFF
--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -48,7 +48,7 @@ export class DayPlannerSettingsTab extends PluginSettingTab {
 
       new Setting(containerEl)
         .setName('Day Planner File Name Format')
-        .setDesc('File Name format (insert date in {{data:moment format}})')
+        .setDesc('File Name format (Date should be inputed in the moment format. eg. {{date:DD-MM-YYYY}}')
         .addText(component =>
           component
             .setValue(this.plugin.settings.dayPlannerFileName)

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -48,7 +48,7 @@ export class DayPlannerSettingsTab extends PluginSettingTab {
 
       new Setting(containerEl)
         .setName('Day Planner File Name Format')
-        .setDesc('File Name format (Date should be inputed in the moment format. eg. {{date:DD-MM-YYYY}}')
+        .setDesc('File Name format (Date should be imputted in the moment format. eg. {{date:DD-MM-YYYY}}')
         .addText(component =>
           component
             .setValue(this.plugin.settings.dayPlannerFileName)


### PR DESCRIPTION
The original description lead an inexperienced user to believe that the format should be imputed as `{{data:DD-MM-YY}}` instead of `{{date:DD-MM-YY}}`. I've fixed the one letter typo and also refined the description to provide an example.